### PR TITLE
million to one million spelling adjustments

### DIFF
--- a/src/NumeroALetras.php
+++ b/src/NumeroALetras.php
@@ -245,7 +245,7 @@ class NumeroALetras
 
         if (intval($millones) > 0) {
             if ($millones == '001') {
-                $converted .= 'UN MILLON ';
+                $converted .= 'UN MILLÓN ';
             } elseif (intval($millones) > 0) {
                 $converted .= sprintf('%sMILLONES ', $this->convertGroup($millones));
             }


### PR DESCRIPTION
spelling adjustments million for million with tilde in the o, with this PR you can avoid creating a patch in the web portals to adjust this spelling mistake.